### PR TITLE
Add option to pass user define error handler to RestUri class

### DIFF
--- a/R/HTTP-class.R
+++ b/R/HTTP-class.R
@@ -65,7 +65,7 @@ HTTP <- function(accept = acceptedMediaTypes()) {
 ###
 
 defaultErrorHandler <- function(response) {
-  stop(paste(response$statusMessage))
+  stop(response$statusMessage)
 }
 
 handleResponse <- function(content, reader, cache.info = NULL,
@@ -78,9 +78,8 @@ handleResponse <- function(content, reader, cache.info = NULL,
         unauthorized()
     }
     if (is(content, "try-error")) {
-      body <- response$body
-      body <- as(body, "application/json")
-      body <- as(body, mediaTarget(body))
+      media <- responseToMedia(response)
+      body <- as(media, mediaTarget(media))
       responseError <- list(status = status, statusMessage = statusMessage,
                             body = body)
       errorHandler(responseError)

--- a/R/RestUri-class.R
+++ b/R/RestUri-class.R
@@ -12,7 +12,8 @@ setClassUnion("CredentialsORNULL", c("Credentials", "NULL"))
 setClass("RestUri",
          representation(cache = "MediaCache",
                         protocol = "CRUDProtocol",
-                        credentials = "CredentialsORNULL"),
+                        credentials = "CredentialsORNULL",
+                        errorHandler = "function"),
          contains = "character")
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -26,6 +27,7 @@ globalRestClientCache <- local({
 
 RestUri <- function(base.uri, protocol = CRUDProtocol(base.uri, ...),
                     cache = globalRestClientCache(),
+                    errorHandler = defaultErrorHandler,
                     ...)
 {
   if (!isSingleString(base.uri))
@@ -35,7 +37,7 @@ RestUri <- function(base.uri, protocol = CRUDProtocol(base.uri, ...),
   base.uri <- sub("/$", "", base.uri)
   credentials <- findCredentials(base.uri)
   new("RestUri", base.uri, protocol = protocol, cache = cache,
-      credentials = credentials)
+      credentials = credentials, errorHandler = errorHandler)
 }
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Hey @lawremi,

With these updated changes, the user can provide a custom error handler function to RestUri constructor.
For now, the error handler function should accept one parameters(response) to work correctly.

Default Error handler Output:
```R
library(restfulr)
url <- RestUri("http://api.genome.ucsc.edu/list/tracks")
read(url, genome = "xyz")

Error: Bad Request
```

Custom Error handler Output:
```R
library(restfulr)
handler <- function(response) { stop(response$body$error) }
url <- RestUri("http://api.genome.ucsc.edu/list/tracks", errorHandler = handler)
read(url, genome = "xyz")

Error in errorHandler(responseError) :
  can not find genome genome='xyz' for endpoint '/list/tracks'
```

let me know if there is anything that needs improvement