### PR TITLE
Add https support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.so
 symbols.rds
 */.Rhistory
+.Rproj.user
+.RData
+.Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Collate:
     CacheInfo-class.R
     Credentials-class.R
     HTTP-class.R
+    HTTPS-class.R
     Media-class.R
     MediaCache-class.R
     RestUri-class.R

--- a/R/HTTPS-class.R
+++ b/R/HTTPS-class.R
@@ -1,0 +1,211 @@
+### =========================================================================
+### HTTPS protocol implementation
+### -------------------------------------------------------------------------
+
+.HTTPS <- setRefClass("HTTPS",
+                     fields = list(
+                       accept = "character"
+                       ),
+                     contains = "CRUDProtocol")
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Constructor
+###
+
+HTTPS <- function(accept = acceptedMediaTypes()) {
+  if (!is.character(accept) || any(is.na(accept)))
+    stop("'accept' must be a character() without NAs")
+  .HTTPS$new(accept = accept)
+}
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### CRUD implementation
+###
+
+.HTTPS$methods(create = function(x, value, ...) {
+  if (!isSingleString(x))
+    stop("'x' must be a single, non-NA string representing a URL")
+  curl <- getCurlHandle()
+  reader <- dynCurlReader(curl)
+  opts <- curlOptions(postfields = paste(value, collapse="\n"),
+                      httpheader = c(
+                        Accept = accept(.self),
+                        'Content-Type' = contentType(value),
+                        Authorization = authorization(x),
+                          ...),
+                      headerfunction = reader$update)
+  content <- try(postForm(x, .opts=opts, curl=curl), silent=TRUE)
+  invisible(handleResponse(content, reader, errorHandler = x@errorHandler))
+})
+
+.HTTPS$methods(read = function(x, cache.info, ...) {
+  if (!isSingleString(x))
+    stop("'x' must be a single, non-NA string representing a URL")
+  request.header <- c(headerFromCacheInfo(cache.info),
+                      Authorization = authorization(x),
+                      Accept = accept(.self),
+                      ...)
+  ## We use our own reader so that we can return the body in case of error
+  curl <- getCurlHandle(httpheader = request.header)
+  reader <- dynCurlReader(curl)
+  content <- try(getURLContent(x, header = reader, curl = curl), silent=TRUE)
+  handleResponse(content, reader, cache.info, x@errorHandler)
+})
+
+.HTTPS$methods(update = function(x, ..., value) {
+  stop("PUT support not yet implemented")
+})
+
+.HTTPS$methods(delete = function(x, ...) {
+  stop("DELETE support not yet implemented")
+})
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Helpers
+###
+
+defaultErrorHandler <- function(response) {
+  stop(response$statusMessage)
+}
+
+handleResponse <- function(content, reader, cache.info = NULL,
+                           errorHandler = defaultErrorHandler) {
+    response <- list(header = parseHTTPHeader(reader$header()),
+                     body = reader$value())
+    status <- as.integer(response$header["status"])
+    statusMessage <- response$header["statusMessage"]
+    if (identical(status, HTTP_STATUS$Unauthorized)) {
+        unauthorized()
+    }
+    if (is(content, "try-error")) {
+      media <- responseToMedia(response)
+      body <- as(media, mediaTarget(media))
+      responseError <- list(status = status, statusMessage = statusMessage,
+                            body = body)
+      errorHandler(responseError)
+    }
+    if (identical(status, HTTP_STATUS$No_Content)) {
+        response <- NULL
+    }
+    if (!is.null(cache.info) && identical(status, HTTP_STATUS$Not_Modified)) {
+        cacheInfoFromHeader(response$header, cache.info)
+    } else {
+        responseToMedia(response)
+    }
+}
+
+coercionTable <- function() {
+    signatures <- names(getMethods(coerce, table = TRUE))
+    matrix(unlist(strsplit(signatures, "#")), ncol=2L, byrow=TRUE,
+           dimnames=list(NULL, c("from", "to")))
+}
+
+mediaCoercionTable <- function() {
+    tab <- coercionTable()
+    classes <- names(getClass("Media")@subclasses)
+    tab[rowSums(matrix(tab %in% classes, ncol=2L)) == 1L,]
+}
+
+acceptedMediaTypes <- function() {
+    intersect(mediaCoercionTable()[,"from"],
+              names(getClass("Media")@subclasses))
+}
+
+responseToMedia <- function(x) {
+  content.type <- head(attr(x$body, "Content-Type"), 1)
+  content.params <- tail(attr(x$body, "Content-Type"), -1)
+  media.class <- mediaClassFromContentType(content.type)
+  content.params <-
+    content.params[intersect(names(content.params), slotNames(media.class))]
+  if (media.class == "NullMedia") {
+    new("NullMedia", cacheInfo = cacheInfoFromHeader(x$header))
+  } else {
+    do.call(new, c(media.class, x$body,
+                   cacheInfo = cacheInfoFromHeader(x$header),
+                   content.params))
+  }
+}
+
+mediaClassFromContentType <- function(x) {
+  if (is.null(x))
+    "NullMedia"
+  else if (is.character(x)) {
+    if (isClass(x))
+      x
+    else sub("/.*", "/*", x)
+  } else stop("content type should be character or NULL")
+}
+
+headerFromCacheInfo <- function(x) {
+  if (is.null(x))
+    NULL
+  else c("If-None-Match" = x@hash,
+         "If-Modified-Since" = formatHTTPDate(x@lastModified))
+}
+
+cacheInfoFromHeader <- function(x, original = CacheInfo()) {
+  x <- as.list(x)
+  cache.control <- parseCacheControl(x[["Cache-Control"]])
+  if (isTRUE(cache.control[["no-cache"]]))
+    expires <- Sys.time()
+  else if (!is.null(cache.control[["max-age"]]))
+    expires <- Sys.time() + cache.control[["max-age"]]
+  else expires <- parseHTTPDate(x[["Expires"]])
+  info.args <- list(expires = expires,
+                    lastModified = parseHTTPDate(x[["Last-Modified"]]),
+                    hash = x[["ETag"]])
+  info.args <- Filter(Negate(is.null), info.args)
+  do.call(initialize, c(original, info.args))
+}
+
+parseCacheControl <- function(x) {
+  if (is.null(x))
+    return(NULL)
+  fields <- strsplit(x, ", ")[[1]]
+  key.val <- strsplit(fields, "=")
+  keys <- sapply(key.val, head, 1)
+  has.val <- sapply(key.val, length) > 1L
+  l <- list()
+  l[keys[!has.val]] <- TRUE
+  l[keys[has.val]] <- sapply(key.val[has.val], tail, 1)
+  if (!is.null(l[["max-age"]]))
+    l[["max-age"]] <- as.integer(l[["max-age"]])
+  l
+}
+
+.httpParseDateString <- "%a, %d %b %Y %H:%M:%S"
+.httpFormatDateString <- paste(.httpParseDateString, "%Z")
+
+formatHTTPDate <- function(x) {
+  format(x, .httpFormatDateString, tz = "GMT")
+}
+
+parseHTTPDate <- function(x) {
+  if (is.null(x))
+    NULL
+  else strptime(x, .httpParseDateString, tz = "GMT")
+}
+
+authorization <- function(x) {
+    credentials <- credentials(x)
+    if (!is.null(credentials)) {
+        auth <- paste0(username(credentials), ":", password(credentials))
+        paste("Basic", base64(auth))
+    }
+}
+
+accept <- function(x) {
+  paste(x$accept, collapse=", ")
+}
+
+stopIfHTTPError <- function(header) {
+  stop.if.HTTPS.error <- get("stop.if.HTTPS.error", getNamespace("RCurl"))
+  stop.if.HTTPS.error(header)
+}
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Status code constants
+###
+
+HTTP_STATUS <- setNames(as.list(as.integer(names(RCurl:::httpErrorClasses))),
+                        RCurl:::httpErrorClasses)

--- a/restfulr.Rproj
+++ b/restfulr.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This is a simple attempt to get restfulr to work with https RESTful servers.

I have essentially duplicated the existing http code and done a search and replace. There is no additional code for authentication.

For ease of working with RStudio I have added an . Rproj file.

Can anyone provide some examples of current use of restfulr which I can work to test this code against? Examples in the documentation appear to point to servers which have moved (some of them, to https).

My motivation for adding this is to make it possible to access some countries' statistics databases which may be accessible through a RESTful web interface. These typically offer xml or json downloads. I am currently stumped by getting "application/force-download" or "application/*" returned and the system being unable to parse them.

**Edit**: With more digging I found that some of the statistics I was looking for are offered through an SDMX api, which can be access with the `rsdmx` package. My "immediate" need to get `restfulr` running with https is overtaken but I would be happy to try getting this patch into better shape if there is interest.